### PR TITLE
OPENEUROPA-1238: Allow minor updates for PHP Parser.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "drupal/config_devel": "~1.2",
         "drupal/drupal-extension": "^4.0.0@alpha",
         "drush/drush": "~9.0",
-        "nikic/php-parser": "~3.1.5",
+        "nikic/php-parser": "^3.1.5",
         "openeuropa/code-review": "^1.0.0-alpha4",
         "openeuropa/drupal-core-require-dev": "^8.6",
         "openeuropa/task-runner": "~1.0"


### PR DESCRIPTION
## OPENEUROPA-1238

### Description

Followup for #24. The PHP Parser dependency is too tightly constrained.

### Change log

- Added: Nil
- Changed: 1 character
- Deprecated: Zilch
- Removed: Nada
- Fixed: Zero
- Security: Nought

### Commands

```
sudo make_me_a_sandwich
```