### PR TITLE
OPENEUROPA-1547: Rename Listing item paragraph bundle to Listing.

### DIFF
--- a/config/install/paragraphs.paragraphs_type.oe_list_item.yml
+++ b/config/install/paragraphs.paragraphs_type.oe_list_item.yml
@@ -2,7 +2,7 @@ langcode: en
 status: true
 dependencies: {  }
 id: oe_list_item
-label: 'List item'
+label: 'Listing item'
 icon_uuid: null
 description: 'Use a "List item" when you wish to display content teasers. A list item is available in the following variants: default, date item, highlighted and thumbnail with primary or secondary image.'
 behavior_plugins: {  }

--- a/config/install/paragraphs.paragraphs_type.oe_list_item_block.yml
+++ b/config/install/paragraphs.paragraphs_type.oe_list_item_block.yml
@@ -2,7 +2,7 @@ langcode: en
 status: true
 dependencies: {  }
 id: oe_list_item_block
-label: 'List item block'
+label: 'Listing item block'
 icon_uuid: null
 description: 'Display multiple list items organised in columns.'
 behavior_plugins: {  }

--- a/tests/features/create-landing-page.feature
+++ b/tests/features/create-landing-page.feature
@@ -6,10 +6,10 @@ Feature: Create a landing page
 
   Scenario: All supported paragraph types are available
     Then the following paragraph types are available for "demo landing page" content:
-      | Accordion       |
-      | Content row     |
-      | Links block     |
-      | List item       |
-      | List item block |
-      | Quote           |
-      | Rich text       |
+      | Accordion          |
+      | Content row        |
+      | Links block        |
+      | Listing item       |
+      | Listing item block |
+      | Quote              |
+      | Rich text          |


### PR DESCRIPTION
Rename Listing item paragraph bundle to Listing in order to follow the ECL convention.