### PR TITLE
OPENEUROPA-1548: Provide documentation for Links block component.

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,3 +129,9 @@ Please read [the full documentation](https://github.com/openeuropa/openeuropa) f
 We use [SemVer](http://semver.org/) for versioning. For the available versions, see the [tags on this repository](https://github.com/openeuropa/oe_paragraphs/tags).
 
 [1]: https://www.drupal.org/docs/develop/using-composer/using-composer-to-manage-drupal-site-dependencies#managing-contributed
+
+## Components
+
+#### Links block
+The links block component displays a list of links, with an optional title. It is used for instance with the dropdown component.
+The component is intended to be used in the sidebar area only. Currently it is not being used in the main content area.

--- a/config/install/paragraphs.paragraphs_type.oe_links_block.yml
+++ b/config/install/paragraphs.paragraphs_type.oe_links_block.yml
@@ -4,5 +4,5 @@ dependencies: {  }
 id: oe_links_block
 label: 'Links block'
 icon_uuid: null
-description: 'A set of links with an optional title.'
+description: 'A set of links with an optional title. This component should be placed in the sidebar only.'
 behavior_plugins: {  }


### PR DESCRIPTION
Instead of removal, we provide documentation for the component. The component is still usable but in the correct context, therefore we don't see the need of removing it from the code.