### PR TITLE
OPENEUROPA-1752: Hiding non-translatable fields on translation forms for all paragraph types.

### DIFF
--- a/config/optional/language.content_settings.paragraph.oe_accordion.yml
+++ b/config/optional/language.content_settings.paragraph.oe_accordion.yml
@@ -9,7 +9,7 @@ third_party_settings:
   content_translation:
     enabled: true
     bundle_settings:
-      untranslatable_fields_hide: '0'
+      untranslatable_fields_hide: '1'
 id: paragraph.oe_accordion
 target_entity_type_id: paragraph
 target_bundle: oe_accordion

--- a/config/optional/language.content_settings.paragraph.oe_accordion_item.yml
+++ b/config/optional/language.content_settings.paragraph.oe_accordion_item.yml
@@ -9,7 +9,7 @@ third_party_settings:
   content_translation:
     enabled: true
     bundle_settings:
-      untranslatable_fields_hide: '0'
+      untranslatable_fields_hide: '1'
 id: paragraph.oe_accordion_item
 target_entity_type_id: paragraph
 target_bundle: oe_accordion_item

--- a/config/optional/language.content_settings.paragraph.oe_content_row.yml
+++ b/config/optional/language.content_settings.paragraph.oe_content_row.yml
@@ -9,7 +9,7 @@ third_party_settings:
   content_translation:
     enabled: true
     bundle_settings:
-      untranslatable_fields_hide: '0'
+      untranslatable_fields_hide: '1'
 id: paragraph.oe_content_row
 target_entity_type_id: paragraph
 target_bundle: oe_content_row

--- a/config/optional/language.content_settings.paragraph.oe_links_block.yml
+++ b/config/optional/language.content_settings.paragraph.oe_links_block.yml
@@ -9,7 +9,7 @@ third_party_settings:
   content_translation:
     enabled: true
     bundle_settings:
-      untranslatable_fields_hide: '0'
+      untranslatable_fields_hide: '1'
 id: paragraph.oe_links_block
 target_entity_type_id: paragraph
 target_bundle: oe_links_block

--- a/config/optional/language.content_settings.paragraph.oe_list_item.yml
+++ b/config/optional/language.content_settings.paragraph.oe_list_item.yml
@@ -9,7 +9,7 @@ third_party_settings:
   content_translation:
     enabled: true
     bundle_settings:
-      untranslatable_fields_hide: '0'
+      untranslatable_fields_hide: '1'
 id: paragraph.oe_list_item
 target_entity_type_id: paragraph
 target_bundle: oe_list_item

--- a/config/optional/language.content_settings.paragraph.oe_list_item_block.yml
+++ b/config/optional/language.content_settings.paragraph.oe_list_item_block.yml
@@ -9,7 +9,7 @@ third_party_settings:
   content_translation:
     enabled: true
     bundle_settings:
-      untranslatable_fields_hide: '0'
+      untranslatable_fields_hide: '1'
 id: paragraph.oe_list_item_block
 target_entity_type_id: paragraph
 target_bundle: oe_list_item_block

--- a/config/optional/language.content_settings.paragraph.oe_quote.yml
+++ b/config/optional/language.content_settings.paragraph.oe_quote.yml
@@ -9,7 +9,7 @@ third_party_settings:
   content_translation:
     enabled: true
     bundle_settings:
-      untranslatable_fields_hide: '0'
+      untranslatable_fields_hide: '1'
 id: paragraph.oe_quote
 target_entity_type_id: paragraph
 target_bundle: oe_quote

--- a/config/optional/language.content_settings.paragraph.oe_rich_text.yml
+++ b/config/optional/language.content_settings.paragraph.oe_rich_text.yml
@@ -9,7 +9,7 @@ third_party_settings:
   content_translation:
     enabled: true
     bundle_settings:
-      untranslatable_fields_hide: '0'
+      untranslatable_fields_hide: '1'
 id: paragraph.oe_rich_text
 target_entity_type_id: paragraph
 target_bundle: oe_rich_text

--- a/oe_paragraphs.install
+++ b/oe_paragraphs.install
@@ -186,14 +186,12 @@ function oe_paragraphs_update_8001(array &$sandbox): void {
 
 /**
  * Update the content translation settings of the existing paragraphs types.
- *
- * We need to update all paragraph types to hide the non-translatable fields on
- * translation forms because otherwise the paragraphs don't work with
- * content moderation.
- *
- * @see https://www.drupal.org/docs/8/modules/paragraphs/multilingual-and-content-moderation
  */
 function oe_paragraphs_update_8002(&$sandbox) {
+  // We need to update all paragraph types to hide the non-translatable fields
+  // on translation forms because otherwise the paragraphs don't work with
+  // content moderation.
+  // @see https://www.drupal.org/docs/8/modules/paragraphs/multilingual-and-content-moderation
   $ids = [
     'paragraph.oe_accordion',
     'paragraph.oe_accordion_item',

--- a/oe_paragraphs.install
+++ b/oe_paragraphs.install
@@ -183,3 +183,40 @@ function oe_paragraphs_update_8001(array &$sandbox): void {
     }
   }
 }
+
+/**
+ * Update the content translation settings of the existing paragraphs types.
+ *
+ * We need to update all paragraph types to hide the non-translatable fields on
+ * translation forms because otherwise the paragraphs don't work with
+ * content moderation.
+ *
+ * @see https://www.drupal.org/docs/8/modules/paragraphs/multilingual-and-content-moderation
+ */
+function oe_paragraphs_update_8002(&$sandbox) {
+  $ids = [
+    'paragraph.oe_accordion',
+    'paragraph.oe_accordion_item',
+    'paragraph.oe_content_row',
+    'paragraph.oe_links_block',
+    'paragraph.oe_list_item',
+    'paragraph.oe_list_item_block',
+    'paragraph.oe_quote',
+    'paragraph.oe_rich_text',
+  ];
+
+  /** @var \Drupal\language\ContentLanguageSettingsInterface[] $content_settings */
+  $content_settings = \Drupal::entityTypeManager()->getStorage('language_content_settings')->loadMultiple($ids);
+  foreach ($content_settings as $settings) {
+    $bundle_settings = $settings->getThirdPartySetting('content_translation', 'bundle_settings');
+    if (!$bundle_settings) {
+      continue;
+    }
+
+    if ($bundle_settings['untranslatable_fields_hide'] !== '1') {
+      $bundle_settings['untranslatable_fields_hide'] = '1';
+      $settings->setThirdPartySetting('content_translation', 'bundle_settings', $bundle_settings);
+      $settings->save();
+    }
+  }
+}


### PR DESCRIPTION
This fixes the paragraphs vs content moderation problem we've been having.
