### PR TITLE
OPENEUROPA-1913: Make link text and url in contextual navigation required

### DIFF
--- a/config/install/field.field.paragraph.oe_contextual_navigation.field_oe_links.yml
+++ b/config/install/field.field.paragraph.oe_contextual_navigation.field_oe_links.yml
@@ -12,11 +12,11 @@ entity_type: paragraph
 bundle: oe_contextual_navigation
 label: Links
 description: ''
-required: false
+required: true
 translatable: true
 default_value: {  }
 default_value_callback: ''
 settings:
   link_type: 17
-  title: 1
+  title: 2
 field_type: link

--- a/tests/features/contextual-navigation.feature
+++ b/tests/features/contextual-navigation.feature
@@ -15,13 +15,18 @@ Feature: Contextual navigation paragraph.
     And the following fields should not be present "Variant"
 
     When I press "Save"
-    # No fields are required.
+    Then I should see the following error messages:
+      | error messages              |
+      | URL field is required       |
+      | Link text field is required |
+
+    When I fill in "URL" with "<front>" in the 1st "Contextual navigation" paragraph
+    And I fill in "Link text" with "Back to the home" in the 1st "Contextual navigation" paragraph
+    And I press "Save"
     Then I should see the heading "Contextual navigation test page"
 
     When I click "Edit"
     And I fill in "Navigation label" with "Quick links" in the 1st "Contextual navigation" paragraph
-    And I fill in "URL" with "<front>" in the 1st "Contextual navigation" paragraph
-    And I fill in "Link text" with "Back to the home" in the 1st "Contextual navigation" paragraph
     And I fill in "Limit" with "97" in the 1st "Contextual navigation" paragraph
     And I fill in "More label" with "See more" in the 1st "Contextual navigation" paragraph
     And I press "Save"


### PR DESCRIPTION
## OPENEUROPA-1913

### Description

Make link text and url in contextual navigation required.

### Change log

- Changed: link text and url in contextual navigation are now required.
- Changed: behat test for link text and url in contextual navigation
