### PR TITLE
OPENEUROPA-2487: Date field should not be translatable.

### DIFF
--- a/config/install/field.field.paragraph.oe_list_item.field_oe_date.yml
+++ b/config/install/field.field.paragraph.oe_list_item.field_oe_date.yml
@@ -13,7 +13,7 @@ bundle: oe_list_item
 label: Date
 description: 'Date information.'
 required: false
-translatable: true
+translatable: false
 default_value: {  }
 default_value_callback: ''
 settings: {  }


### PR DESCRIPTION
No upgrade path needed here because we don't want to force users of the component to automatically change their field config. They have the option to run their own upgrade path if they want.