### PR TITLE
OPENEUROPA-2473: Add Social media follow paragraph to Content row paragraph 

### DIFF
--- a/config/install/field.field.paragraph.oe_content_row.field_oe_paragraphs.yml
+++ b/config/install/field.field.paragraph.oe_content_row.field_oe_paragraphs.yml
@@ -33,32 +33,39 @@ settings:
       oe_list_item_block: oe_list_item_block
       oe_quote: oe_quote
       oe_rich_text: oe_rich_text
+      oe_social_media_follow: oe_social_media_follow
     target_bundles_drag_drop:
-      oe_accordion:
-        enabled: true
-        weight: 9
-      oe_accordion_item:
-        weight: 10
-        enabled: false
-      oe_content_row:
-        weight: 11
-        enabled: false
-      oe_links_block:
-        enabled: true
-        weight: 12
-      oe_contextual_navigation:
-        enabled: true
-        weight: 13
-      oe_list_item:
-        weight: 13
-        enabled: false
-      oe_list_item_block:
-        enabled: true
-        weight: 14
-      oe_quote:
-        enabled: true
-        weight: 15
       oe_rich_text:
         enabled: true
-        weight: 16
+        weight: -22
+      oe_list_item_block:
+        enabled: true
+        weight: -21
+      oe_links_block:
+        enabled: true
+        weight: -20
+      oe_quote:
+        enabled: true
+        weight: -19
+      block_reference:
+        enabled: true
+        weight: -18
+      oe_social_media_follow:
+        enabled: true
+        weight: -17
+      oe_contextual_navigation:
+        enabled: true
+        weight: -16
+      oe_accordion:
+        enabled: true
+        weight: -15
+      oe_accordion_item:
+        weight: -14
+        enabled: false
+      oe_content_row:
+        weight: -13
+        enabled: false
+      oe_list_item:
+        weight: -12
+        enabled: false
 field_type: entity_reference_revisions

--- a/config/install/field.field.paragraph.oe_social_media_follow.field_oe_social_media_variant.yml
+++ b/config/install/field.field.paragraph.oe_social_media_follow.field_oe_social_media_variant.yml
@@ -12,7 +12,7 @@ entity_type: paragraph
 bundle: oe_social_media_follow
 label: Variant
 description: ''
-required: false
+required: true
 translatable: false
 default_value:
   -

--- a/oe_paragraphs.post_update.php
+++ b/oe_paragraphs.post_update.php
@@ -76,9 +76,7 @@ function oe_paragraphs_post_update_10002(array &$sandbox): void {
 }
 
 /**
- * Add Social media follow paragraph to Content row paragraph.
- *
- * Set Variant field required.
+ * Set Variant required and add Social media follow to Content row.
  */
 function oe_paragraphs_post_update_10003(array &$sandbox): void {
   $paragraph_weights = [
@@ -96,8 +94,8 @@ function oe_paragraphs_post_update_10003(array &$sandbox): void {
     $handler_settings['target_bundles']['oe_social_media_follow'] = 'oe_social_media_follow';
   }
   // Reorder paragraphs.
-  foreach ($paragraph_weights as $paragraph => $weight) {
-    if (isset($handler_settings['target_bundles_drag_drop'])) {
+  if (isset($handler_settings['target_bundles_drag_drop'])) {
+    foreach ($paragraph_weights as $paragraph => $weight) {
       $handler_settings['target_bundles_drag_drop'][$paragraph]['weight'] = $weight;
     }
   }

--- a/oe_paragraphs.post_update.php
+++ b/oe_paragraphs.post_update.php
@@ -77,6 +77,8 @@ function oe_paragraphs_post_update_10002(array &$sandbox): void {
 
 /**
  * Add Social media follow paragraph to Content row paragraph.
+ *
+ * Set Variant field required.
  */
 function oe_paragraphs_post_update_10003(array &$sandbox): void {
   $paragraph_weights = [
@@ -87,11 +89,13 @@ function oe_paragraphs_post_update_10003(array &$sandbox): void {
     'oe_list_item_block' => -21,
     'oe_rich_text' => -22,
   ];
+  // Add Social media follow paragraph to content row.
   $field = FieldConfig::load('paragraph.oe_content_row.field_oe_paragraphs');
   $handler_settings = $field->getSetting('handler_settings');
   if (isset($handler_settings['target_bundles'])) {
     $handler_settings['target_bundles']['oe_social_media_follow'] = 'oe_social_media_follow';
   }
+  // Reorder paragraphs.
   foreach ($paragraph_weights as $paragraph => $weight) {
     if (isset($handler_settings['target_bundles_drag_drop'])) {
       $handler_settings['target_bundles_drag_drop'][$paragraph]['weight'] = $weight;
@@ -99,13 +103,16 @@ function oe_paragraphs_post_update_10003(array &$sandbox): void {
   }
   $field->setSetting('handler_settings', $handler_settings);
   $field->save();
+
+  // Set Variant field required.
+  $field = FieldConfig::load('paragraph.oe_social_media_follow.field_oe_social_media_variant');
+  $field->setRequired(TRUE);
+  $field->save();
 }
 
 /**
  * Set Social media follow Variant field to required.
  */
 function oe_paragraphs_post_update_10004(array &$sandbox): void {
-  $field = FieldConfig::load('paragraph.oe_social_media_follow.field_oe_social_media_variant');
-  $field->setRequired(TRUE);
-  $field->save();
+
 }

--- a/oe_paragraphs.post_update.php
+++ b/oe_paragraphs.post_update.php
@@ -100,3 +100,12 @@ function oe_paragraphs_post_update_10003(array &$sandbox): void {
   $field->setSetting('handler_settings', $handler_settings);
   $field->save();
 }
+
+/**
+ * Set Social media follow Variant field to required.
+ */
+function oe_paragraphs_post_update_10004(array &$sandbox): void {
+  $field = FieldConfig::load('paragraph.oe_social_media_follow.field_oe_social_media_variant');
+  $field->setRequired(TRUE);
+  $field->save();
+}

--- a/oe_paragraphs.post_update.php
+++ b/oe_paragraphs.post_update.php
@@ -76,33 +76,9 @@ function oe_paragraphs_post_update_10002(array &$sandbox): void {
 }
 
 /**
- * Set Variant required and add Social media follow to Content row.
+ * Set Variant field required for Social media follow paragraph.
  */
 function oe_paragraphs_post_update_10003(array &$sandbox): void {
-  $paragraph_weights = [
-    'oe_social_media_follow' => -17,
-    'block_reference' => -18,
-    'oe_quote' => -19,
-    'oe_links_block' => -20,
-    'oe_list_item_block' => -21,
-    'oe_rich_text' => -22,
-  ];
-  // Add Social media follow paragraph to content row.
-  $field = FieldConfig::load('paragraph.oe_content_row.field_oe_paragraphs');
-  $handler_settings = $field->getSetting('handler_settings');
-  if (isset($handler_settings['target_bundles'])) {
-    $handler_settings['target_bundles']['oe_social_media_follow'] = 'oe_social_media_follow';
-  }
-  // Reorder paragraphs.
-  if (isset($handler_settings['target_bundles_drag_drop'])) {
-    foreach ($paragraph_weights as $paragraph => $weight) {
-      $handler_settings['target_bundles_drag_drop'][$paragraph]['weight'] = $weight;
-    }
-  }
-  $field->setSetting('handler_settings', $handler_settings);
-  $field->save();
-
-  // Set Variant field required.
   $field = FieldConfig::load('paragraph.oe_social_media_follow.field_oe_social_media_variant');
   $field->setRequired(TRUE);
   $field->save();

--- a/oe_paragraphs.post_update.php
+++ b/oe_paragraphs.post_update.php
@@ -109,10 +109,3 @@ function oe_paragraphs_post_update_10003(array &$sandbox): void {
   $field->setRequired(TRUE);
   $field->save();
 }
-
-/**
- * Set Social media follow Variant field to required.
- */
-function oe_paragraphs_post_update_10004(array &$sandbox): void {
-
-}

--- a/oe_paragraphs.post_update.php
+++ b/oe_paragraphs.post_update.php
@@ -74,3 +74,29 @@ function oe_paragraphs_post_update_10002(array &$sandbox): void {
     $entity->save();
   }
 }
+
+/**
+ * Add Social media follow paragraph to Content row paragraph.
+ */
+function oe_paragraphs_post_update_10003(array &$sandbox): void {
+  $paragraph_weights = [
+    'oe_social_media_follow' => -17,
+    'block_reference' => -18,
+    'oe_quote' => -19,
+    'oe_links_block' => -20,
+    'oe_list_item_block' => -21,
+    'oe_rich_text' => -22,
+  ];
+  $field = FieldConfig::load('paragraph.oe_content_row.field_oe_paragraphs');
+  $handler_settings = $field->getSetting('handler_settings');
+  if (isset($handler_settings['target_bundles'])) {
+    $handler_settings['target_bundles']['oe_social_media_follow'] = 'oe_social_media_follow';
+  }
+  foreach ($paragraph_weights as $paragraph => $weight) {
+    if (isset($handler_settings['target_bundles_drag_drop'])) {
+      $handler_settings['target_bundles_drag_drop'][$paragraph]['weight'] = $weight;
+    }
+  }
+  $field->setSetting('handler_settings', $handler_settings);
+  $field->save();
+}

--- a/tests/features/content-row.feature
+++ b/tests/features/content-row.feature
@@ -14,12 +14,13 @@ Feature: Content row paragraph.
     # Verify the fields displayed in the "default" variant.
     And the following field should not be present "Navigation title"
     And the "Paragraphs" field in the 1st "Content row" paragraph can reference:
-      | Accordion                 |
-      | Contextual navigation     |
-      | Links block               |
-      | Listing item block        |
-      | Quote                     |
-      | Rich text                 |
+      | Accordion             |
+      | Contextual navigation |
+      | Social media follow   |
+      | Links block           |
+      | Listing item block    |
+      | Quote                 |
+      | Rich text             |
 
     When I select "Inpage navigation" from "Variant" in the 1st "Content row" paragraph
     And I press "Change variant"

--- a/tests/features/social-media-follow.feature
+++ b/tests/features/social-media-follow.feature
@@ -11,6 +11,9 @@ Feature: Social media follow paragraph.
     And I fill in "Title" with "Social media follow paragraph test page"
     And I press "Add Social media follow"
     Then the following fields should be present "Title, URL, Link text, Link type"
+    And the available options in the Variant select should be:
+      | Horizontal |
+      | Vertical   |
     When I press "Save"
     Then I should see the following error messages:
       | error messages          |


### PR DESCRIPTION
## OPENEUROPA-2473: Add Social media follow paragraph to Content row paragraph

### Description

Add Social media follow paragraph to Content row paragraph and set Variant field required.

### Change log

- Added: Social media follow paragraph to Content row paragraph
- Changed: Set Variant field required

### Commands

```sh
drush updb

```

