### PR TITLE
OPENEUROPA-2951: Enabling content translation for the paragraphs currently not translatable.

### DIFF
--- a/config/install/field.field.paragraph.oe_social_media_follow.field_oe_social_media_links.yml
+++ b/config/install/field.field.paragraph.oe_social_media_follow.field_oe_social_media_links.yml
@@ -13,7 +13,7 @@ bundle: oe_social_media_follow
 label: 'Social media links'
 description: ''
 required: true
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings:

--- a/config/install/field.field.paragraph.oe_social_media_follow.field_oe_social_media_see_more.yml
+++ b/config/install/field.field.paragraph.oe_social_media_follow.field_oe_social_media_see_more.yml
@@ -13,7 +13,7 @@ bundle: oe_social_media_follow
 label: 'See more'
 description: ''
 required: false
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings:

--- a/config/optional/language.content_settings.paragraph.oe_social_media_follow.yml
+++ b/config/optional/language.content_settings.paragraph.oe_social_media_follow.yml
@@ -1,0 +1,17 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - paragraphs.paragraphs_type.oe_social_media_follow
+  module:
+    - content_translation
+third_party_settings:
+  content_translation:
+    enabled: true
+    bundle_settings:
+      untranslatable_fields_hide: '1'
+id: paragraph.oe_social_media_follow
+target_entity_type_id: paragraph
+target_bundle: oe_social_media_follow
+default_langcode: site_default
+language_alterable: true

--- a/modules/oe_paragraphs_media/config/optional/language.content_settings.paragraph.oe_text_feature_media.yml
+++ b/modules/oe_paragraphs_media/config/optional/language.content_settings.paragraph.oe_text_feature_media.yml
@@ -1,0 +1,17 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - paragraphs.paragraphs_type.oe_text_feature_media
+  module:
+    - content_translation
+third_party_settings:
+  content_translation:
+    enabled: true
+    bundle_settings:
+      untranslatable_fields_hide: '1'
+id: paragraph.oe_text_feature_media
+target_entity_type_id: paragraph
+target_bundle: oe_text_feature_media
+default_langcode: site_default
+language_alterable: true


### PR DESCRIPTION
## OPENEUROPA-2951

### Description

[Insert description here]

### Change log

- Added:
- Changed:
- Deprecated:
- Removed:
- Fixed:
- Security:

### Commands

```sh
[Insert commands here]

```

