### PR TITLE
OPENEUROPA-3138: Allow to add video media to Text with featured media paragraphs.

### DIFF
--- a/behat.yml.dist
+++ b/behat.yml.dist
@@ -19,6 +19,7 @@ default:
               content management: "/admin/content"
               image creation: "/media/add/image"
               remote video creation: "/media/add/remote_video"
+              avportal video creation: "/media/add/av_portal_video"
               Webtools chart creation: 'media/add/webtools_chart'
               Webtools map creation: 'media/add/webtools_map'
               Webtools social feed creation: 'media/add/webtools_social_feed'

--- a/behat.yml.dist
+++ b/behat.yml.dist
@@ -18,6 +18,7 @@ default:
             pages:
               content management: "/admin/content"
               image creation: "/media/add/image"
+              remote video creation: "/media/add/remote_video"
               Webtools chart creation: 'media/add/webtools_chart'
               Webtools map creation: 'media/add/webtools_map'
               Webtools social feed creation: 'media/add/webtools_social_feed'

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "nikic/php-parser": "~3.0",
         "openeuropa/behat-transformation-context" : "~0.1",
         "openeuropa/code-review": "~1.0@beta",
-        "openeuropa/oe_content": "~1.6.1",
+        "openeuropa/oe_content": "~1.7.0",
         "openeuropa/drupal-core-require-dev": "^8.8",
         "openeuropa/oe_media": "~1.4",
         "openeuropa/oe_webtools": "~1.5.0",

--- a/modules/oe_paragraphs_media/config/install/field.field.paragraph.oe_text_feature_media.field_oe_media.yml
+++ b/modules/oe_paragraphs_media/config/install/field.field.paragraph.oe_text_feature_media.field_oe_media.yml
@@ -21,6 +21,8 @@ settings:
     target_bundles:
       image: image
       av_portal_photo: av_portal_photo
+      av_portal_video: av_portal_video
+      remote_video: remote_video
     sort:
       field: _none
     auto_create: false

--- a/tests/Behat/DrupalContext.php
+++ b/tests/Behat/DrupalContext.php
@@ -98,4 +98,28 @@ class DrupalContext extends RawDrupalContext {
     $this->assertSession()->elementExists('css', "iframe[src*='$partial_iframe_url']");
   }
 
+  /**
+   * Checks that the AV Portal video is rendered.
+   *
+   * @param string $title
+   *   The video title.
+   *
+   * @Then I should see the AV Portal video :title
+   * @TODO: To be removed once oe_content 1.8.0 is released.
+   */
+  public function assertAvPortalVideoIframe(string $title): void {
+    $media = \Drupal::entityTypeManager()->getStorage('media')->loadByProperties(['name' => $title]);
+    if (!$media) {
+      throw new \Exception(sprintf('The media named "%s" does not exist', $title));
+    }
+
+    $media = reset($media);
+    $ref = $media->get('oe_media_avportal_video')->value;
+
+    $iframe = $this->getSession()->getPage()->findAll('css', 'iframe[src*="' . $ref . '"]');
+    if (!$iframe) {
+      throw new \Exception(sprintf('The video named "%s" was not found on the page.', $title));
+    }
+  }
+
 }

--- a/tests/Behat/DrupalContext.php
+++ b/tests/Behat/DrupalContext.php
@@ -4,6 +4,7 @@ declare(strict_types = 1);
 
 namespace Drupal\Tests\oe_paragraphs\Behat;
 
+use Drupal\Core\Url;
 use Drupal\DrupalExtension\Context\RawDrupalContext;
 use Drupal\Tests\oe_paragraphs\Traits\UtilityTrait;
 
@@ -78,6 +79,23 @@ class DrupalContext extends RawDrupalContext {
     $extension = $parts['extension'];
     $filename = $parts['filename'];
     $this->assertSession()->elementExists('css', "img[src*='.$extension'][src*='$filename']");
+  }
+
+  /**
+   * Checks that an OEmbed is present in the page for a certain url.
+   *
+   * @param string $url
+   *   The video url.
+   *
+   * @Then I (should )see the embedded video player for :url
+   */
+  public function assertOembedIframePresent(string $url): void {
+    $partial_iframe_url = Url::fromRoute('media.oembed_iframe', [], [
+      'query' => [
+        'url' => $url,
+      ],
+    ])->toString();
+    $this->assertSession()->elementExists('css', "iframe[src*='$partial_iframe_url']");
   }
 
 }

--- a/tests/features/text-media.feature
+++ b/tests/features/text-media.feature
@@ -6,7 +6,7 @@ Feature: Text with featured media paragraph.
 
   @cleanup:media
   Scenario: Text with featured media paragraph creation.
-    Given I am logged in as a user with the "create oe_demo_landing_page content, access content, edit any oe_demo_landing_page content, create image media, create remote_video media" permission
+    Given I am logged in as a user with the "create oe_demo_landing_page content, access content, edit any oe_demo_landing_page content, create image media, create remote_video media, create av_portal_video media" permission
 
     # Create an "Image" media.
     When I go to "the image creation page"
@@ -19,6 +19,11 @@ Feature: Text with featured media paragraph.
     # Create an "Remote video" media.
     When I go to "the remote video creation page"
     And I fill in "Remote video URL" with "https://www.youtube.com/watch?v=1-g73ty9v04"
+    And I press "Save"
+
+    # Create an "AV Portal video" media
+    When I go to "the avportal video creation page"
+    And I fill in "Media AV Portal Video" with "https://audiovisual.ec.europa.eu/en/video/I-162747"
     And I press "Save"
 
     When I go to "the content management page"
@@ -39,8 +44,15 @@ Feature: Text with featured media paragraph.
     And I should see the text "Caption text"
     And I should see the text "Featured text"
 
-    # Use a video on the Text with featured media paragraph.
+    # Use a remote video on the Text with featured media paragraph.
     When I click "Edit"
     And I fill in "Use existing media" with "Energy, let's save it!"
     And I press "Save"
     Then I should see the embedded video player for "https://www.youtube.com/watch?v=1-g73ty9v04"
+
+    # Use an avportal video on the Text with featured media paragraph.
+    When I click "Edit"
+    And I fill in "Use existing media" with "Midday press briefing from 25/10/2018"
+    And I press "Save"
+    Then I should see the AV Portal video "Midday press briefing from 25/10/2018"
+

--- a/tests/features/text-media.feature
+++ b/tests/features/text-media.feature
@@ -6,7 +6,7 @@ Feature: Text with featured media paragraph.
 
   @cleanup:media
   Scenario: Text with featured media paragraph creation.
-    Given I am logged in as a user with the "create oe_demo_landing_page content, access content, edit any oe_demo_landing_page content, create image media" permission
+    Given I am logged in as a user with the "create oe_demo_landing_page content, access content, edit any oe_demo_landing_page content, create image media, create remote_video media" permission
 
     # Create an "Image" media.
     When I go to "the image creation page"
@@ -16,12 +16,18 @@ Feature: Text with featured media paragraph.
     And I fill in "Alternative text" with "Image Alt Text 1"
     And I press "Save"
 
+    # Create an "Remote video" media.
+    When I go to "the remote video creation page"
+    And I fill in "Remote video URL" with "https://www.youtube.com/watch?v=1-g73ty9v04"
+    And I press "Save"
+
     When I go to "the content management page"
     And I click "Add content"
     And I fill in "Title" with "Text with Featured media paragraph test page"
     And I press "Add Text with Featured media"
     Then the following fields should be present "Title, Use existing media, Caption, Full text"
 
+    # Create a Text with featured media paragraph with an image.
     When I fill in "Title" with "Title text" in the 1st "Text with Featured media" paragraph
     And I fill in "Use existing media" with "My Image 1"
     And I fill in "Caption" with "Caption text" in the 1st "Text with Featured media" paragraph
@@ -32,3 +38,9 @@ Feature: Text with featured media paragraph.
     And I should see the image "example_1.jpeg"
     And I should see the text "Caption text"
     And I should see the text "Featured text"
+
+    # Use a video on the Text with featured media paragraph.
+    When I click "Edit"
+    And I fill in "Use existing media" with "Energy, let's save it!"
+    And I press "Save"
+    Then I should see the embedded video player for "https://www.youtube.com/watch?v=1-g73ty9v04"


### PR DESCRIPTION
## OPENEUROPA-3138
### Description

 Allow to add video media to Text with featured media paragraphs.

### Change log

- Added:
- Changed:  Allow to add video media to Text with featured media paragraphs.
- Deprecated:
- Removed:
- Fixed:
- Security:

### Commands

```sh
[Insert commands here]

```

