### PR TITLE
OPENEUROPA-3159: Use paragraphs patch to solve validation issue.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,7 @@
         "composer/installers": "~1.5",
         "consolidation/robo": "~1.4",
         "consolidation/annotated-command": "^2.8.2",
+        "drupal/coder": "8.3.8",
         "drupal-composer/drupal-scaffold": "~2.5.2",
         "drupal/config_devel": "~1.2",
         "drupal/drupal-extension": "~4.0",
@@ -37,6 +38,7 @@
         "openeuropa/oe_media": "Allows usage of paragraphs with different media attached to it."
     },
     "_readme": [
+        "We explicitly require drupal/coder 8.3.8 or else Drupal coding standards will not be picked up by GrumPHP.",
         "We explicitly require consolidation/robo to allow lower 'composer update --prefer-lowest' to complete successfully.",
         "We explicitly require consolidation/annotated-command to allow lower 'composer update --prefer-lowest' to complete successfully."
     ],

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         "php": ">=7.2",
         "drupal/allowed_formats": "^1.1",
         "drupal/core": "^8.8",
-        "drupal/paragraphs": "^1.8",
+        "drupal/paragraphs": "^1.11",
         "drupal/typed_link": "~1.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -69,6 +69,9 @@
             "drupal/typed_link": {
                 "https://www.drupal.org/project/typed_link/issues/3085826": "https://www.drupal.org/files/issues/2019-10-04/typed_link-3085826-2.patch",
                 "https://www.drupal.org/project/typed_link/issues/3085817": "https://www.drupal.org/files/issues/2019-10-07/typed_link-3085817-3.patch"
+            },
+            "drupal/paragraphs": {
+                "https://www.drupal.org/project/paragraphs/issues/2890086" : "https://www.drupal.org/files/issues/2020-04-29/paragraphs-validation-to-respect-form-display-2890086-42.patch"
             }
         }
     },


### PR DESCRIPTION
## OPENEUROPA-3159
### Description

Complex paragraphs have problems with validation when a field is required but is not shown on the form (if its a variant for example).

### Change log

- Added: Add paragraphs patch to solve the validation problem.
- Changed:
- Deprecated:
- Removed:
- Fixed:
- Security:

### Commands

```sh
[Insert commands here]

```

