### PR TITLE
OEL-856: Hide variants featured_left and featured_right for oe_paragraphs_media.

### DIFF
--- a/modules/oe_paragraphs_media/config/install/core.entity_form_display.paragraph.oe_text_feature_media.left_featured.yml
+++ b/modules/oe_paragraphs_media/config/install/core.entity_form_display.paragraph.oe_text_feature_media.left_featured.yml
@@ -1,5 +1,5 @@
 langcode: en
-status: true
+status: false
 dependencies:
   config:
     - core.entity_form_mode.paragraph.left_featured

--- a/modules/oe_paragraphs_media/config/install/core.entity_form_display.paragraph.oe_text_feature_media.right_featured.yml
+++ b/modules/oe_paragraphs_media/config/install/core.entity_form_display.paragraph.oe_text_feature_media.right_featured.yml
@@ -1,5 +1,5 @@
 langcode: en
-status: true
+status: false
 dependencies:
   config:
     - core.entity_form_mode.paragraph.right_featured

--- a/tests/features/text-media.feature
+++ b/tests/features/text-media.feature
@@ -34,8 +34,6 @@ Feature: Text with featured media paragraph.
     Then the following fields should be present "Heading, Title, Use existing media, Caption, Full text" in the "demo paragraphs element" region
     And the available options in the "Variant" select should be:
       | Text on the left, simple call to action    |
-      | Text on the left, featured call to action  |
-      | Text on the right, featured call to action |
       | Text on the right, simple call to action   |
 
     # Create a Text with featured media paragraph with an image.
@@ -70,15 +68,7 @@ Feature: Text with featured media paragraph.
 
     # Change of variants to ensure presence of the fields.
     When I click "Edit"
-    And I select "Text on the left, featured call to action" from "Variant"
-    And I press "Change variant"
-    Then the following fields should be present "Heading, Title, Use existing media, Caption, Full text, URL, Link text" in the "demo paragraphs element" region
-
     And I select "Text on the left, simple call to action" from "Variant"
-    And I press "Change variant"
-    Then the following fields should be present "Heading, Title, Use existing media, Caption, Full text, URL, Link text" in the "demo paragraphs element" region
-
-    And I select "Text on the right, featured call to action" from "Variant"
     And I press "Change variant"
     Then the following fields should be present "Heading, Title, Use existing media, Caption, Full text, URL, Link text" in the "demo paragraphs element" region
 


### PR DESCRIPTION
## OPENEUROPA-[OEL-856](https://citnet.tech.ec.europa.eu/CITnet/jira/browse/OEL-856)

### Description

Set form display inactive:
* Featured left
* Featured right
And adapt the tests at text-media.feature. For those installing oe_paragraphs_media it will come with those variants set as inactive whilst those who have already installed the module will have them. This is done because BCL will not manage those variants.

### Change log

- Added:
- Changed:
-- text-media.feature
-- core.entity_form_display.paragraph.oe_text_feature_media.left_featured.yml
-- core.entity_form_display.paragraph.oe_text_feature_media.right_featured.yml
- Deprecated:
- Removed:
- Fixed:
- Security:

### Commands

```sh
[Insert commands here]

```

