### PR TITLE
OEL-494: Use the default view mode to render referenced documents.

### DIFF
--- a/modules/oe_paragraphs_document/config/install/core.entity_view_display.paragraph.oe_document.default.yml
+++ b/modules/oe_paragraphs_document/config/install/core.entity_view_display.paragraph.oe_document.default.yml
@@ -10,12 +10,12 @@ bundle: oe_document
 mode: default
 content:
   field_oe_media:
-    weight: 0
+    type: entity_reference_entity_view
     label: above
     settings:
+      view_mode: default
       link: false
-      view_mode: full
     third_party_settings: {  }
-    type: entity_reference_entity_view
+    weight: 0
     region: content
 hidden: {  }


### PR DESCRIPTION
This uniforms it with the rest of entity reference fields.