### PR TITLE
OEL-1890: Use version 3.x of oe_content.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,6 +25,7 @@
         "drupal/description_list_field": "^1.0",
         "drupal/drupal-extension": "^4.0",
         "drupal/entity_browser": "^2.5",
+        "drupal/inline_entity_form": "^1.0-rc12",
         "drupal/json_field": "^1.0.0-rc3",
         "drupaltest/behat-traits": "^0.3",
         "drush/drush": "^10.3",
@@ -33,7 +34,7 @@
         "nikic/php-parser": "^4.12.0",
         "openeuropa/behat-transformation-context": "^0.1",
         "openeuropa/code-review": "^2.0",
-        "openeuropa/oe_content": "^2.8",
+        "openeuropa/oe_content": "3.x-dev",
         "openeuropa/oe_media": "^1.15",
         "openeuropa/oe_webtools": "^1.12",
         "openeuropa/rdf_skos": "^1.0.0-alpha6",
@@ -85,7 +86,8 @@
             "Explicit minimum version requirement of behat library due to PHP compatibility.",
             "Explicit minimum version requirement for symfony/dom-crawler due to its lower versions using the deprecated function libxml_disable_entity_loader() in PHP8.",
             "Explicit requirement of cweagans/composer-patches to allow patches to be applied.",
-            "Explicit minimum version requirement of fabpot/goutte due to Drupal 9.3 compatibility."
+            "Explicit minimum version requirement of fabpot/goutte due to Drupal 9.3 compatibility.",
+            "Explicit minimum version requirement of drupal/inline_entity_form due to failing patch in lower versions. To be removed once oe_media required the same minimum version."
         ]
     },
     "repositories": [


### PR DESCRIPTION
## OPENEUROPA-[Insert ticket number here]

### Description

Use version 3 of oe_content to fix issue with IEF patch.

### Change log

- Added:
- Changed: oe_content version
- Deprecated:
- Removed:
- Fixed:
- Security:

### Commands

```sh
[Insert commands here]

```

