### PR TITLE
Check that paragraph.field_oe_social_media_links exists before doing changes

### DIFF
--- a/oe_paragraphs.post_update.php
+++ b/oe_paragraphs.post_update.php
@@ -240,9 +240,11 @@ function oe_paragraphs_post_update_10008(array &$sandbox) {
  */
 function oe_paragraphs_post_update_10009(): void {
   $field_storage = \Drupal::entityTypeManager()->getStorage('field_storage_config')->load('paragraph.field_oe_social_media_links');
-  $settings = $field_storage->get('settings');
-  $settings['allowed_values']['telegram'] = 'Telegram';
-  $settings['allowed_values']['mastodon'] = 'Mastodon';
-  $field_storage->set('settings', $settings);
-  $field_storage->save();
+  if ($field_storage) {
+    $settings = $field_storage->get('settings');
+    $settings['allowed_values']['telegram'] = 'Telegram';
+    $settings['allowed_values']['mastodon'] = 'Mastodon';
+    $field_storage->set('settings', $settings);
+    $field_storage->save();
+  }
 }


### PR DESCRIPTION
### Description
Hello,
After update to oe_paragraphs 1.15 latest hook_post_update number 10009 is crashing due there is no paragraph.field_oe_social_media_links field in some projects.
As it is not a required field, I suggest to check if that field exists before doing any change.
Regards