### PR TITLE
UCPKN-2795: drush.services.yml is mandatory with Drush 12.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -74,6 +74,11 @@
                 "web-root": "./build"
             }
         },
+        "drush": {
+            "services": {
+                "drush.services.yml": "^11"
+            }
+        },
         "_readme": [
             "Explicit requirement of symfony/phpunit-bridge to replace drupal/core-dev testing classes and traits.",
             "Using symfony/validator v6.2.5 for D10 like core-recommended does because 6.3 breaks BC with the signature changes to the ExecutionContextInterface. Remove when 6.3.1 is realased."

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "drupal/entity_browser": "^2.5",
         "drupal/inline_entity_form": "^1.0-rc12",
         "drupal/json_field": "^1.1",
-        "drush/drush": "^11.1",
+        "drush/drush": "^11.1 || ^12",
         "openeuropa/behat-transformation-context": "^0.1",
         "openeuropa/code-review": "^2.0",
         "openeuropa/oe_content": "^3.0.0-alpha11",

--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,7 @@
         "drupal/inline_entity_form": "^1.0-rc12",
         "drupal/json_field": "^1.1",
         "drush/drush": "^11.1 || ^12",
+        "nikic/php-parser": "^4.17",
         "openeuropa/behat-transformation-context": "^0.1",
         "openeuropa/code-review": "^2.0",
         "openeuropa/oe_content": "^3.0.0-alpha11",
@@ -81,7 +82,8 @@
         },
         "_readme": [
             "Explicit requirement of symfony/phpunit-bridge to replace drupal/core-dev testing classes and traits.",
-            "Using symfony/validator v6.2.5 for D10 like core-recommended does because 6.3 breaks BC with the signature changes to the ExecutionContextInterface. Remove when 6.3.1 is realased."
+            "Using symfony/validator v6.2.5 for D10 like core-recommended does because 6.3 breaks BC with the signature changes to the ExecutionContextInterface. Remove when 6.3.1 is realased.",
+            "Using nikic/php-parser:^4.17 because of https://github.com/phpro/grumphp/issues/1119."
         ]
     },
     "repositories": [

--- a/modules/oe_paragraphs_banner/drush.services.yml
+++ b/modules/oe_paragraphs_banner/drush.services.yml
@@ -1,0 +1,6 @@
+services:
+  oe_paragraphs_banner.banner_paragraph_update:
+    class: Drupal\oe_paragraphs_banner\Commands\UpdateBannerData
+    arguments: [ '@entity_type.manager', '@oe_paragraphs_banner.paragraph_updater', '@messenger' ]
+    tags:
+      - { name: drush.command }

--- a/modules/oe_paragraphs_banner/oe_paragraphs_banner.services.yml
+++ b/modules/oe_paragraphs_banner/oe_paragraphs_banner.services.yml
@@ -2,8 +2,3 @@ services:
   oe_paragraphs_banner.paragraph_updater:
     class: Drupal\oe_paragraphs_banner\BannerParagraphUpdater
     arguments: [ '@entity_type.manager' ]
-  oe_paragraphs_banner.banner_paragraph_update:
-    class: Drupal\oe_paragraphs_banner\Commands\UpdateBannerData
-    arguments: [ '@entity_type.manager', '@oe_paragraphs_banner.paragraph_updater', '@messenger' ]
-    tags:
-      - { name: drush.command }

--- a/modules/oe_paragraphs_carousel/drush.services.yml
+++ b/modules/oe_paragraphs_carousel/drush.services.yml
@@ -1,0 +1,6 @@
+services:
+  oe_paragraphs_carousel.carousel_paragraph_update:
+    class: Drupal\oe_paragraphs_carousel\Commands\UpdateCarouselData
+    arguments: [ '@entity_type.manager', '@oe_paragraphs_carousel.paragraph_updater', '@messenger' ]
+    tags:
+      - { name: drush.command }

--- a/modules/oe_paragraphs_carousel/oe_paragraphs_carousel.services.yml
+++ b/modules/oe_paragraphs_carousel/oe_paragraphs_carousel.services.yml
@@ -2,8 +2,3 @@ services:
   oe_paragraphs_carousel.paragraph_updater:
     class: Drupal\oe_paragraphs_carousel\CarouselParagraphUpdater
     arguments: [ '@entity_type.manager' ]
-  oe_paragraphs_carousel.carousel_paragraph_update:
-    class: Drupal\oe_paragraphs_carousel\Commands\UpdateCarouselData
-    arguments: [ '@entity_type.manager', '@oe_paragraphs_carousel.paragraph_updater', '@messenger' ]
-    tags:
-      - { name: drush.command }


### PR DESCRIPTION
## UCPKN-2795

### Description

Use `drush.services.yml` to declare drush commands.
Fixes the [Issue 217](https://github.com/openeuropa/oe_paragraphs/issues/217).

### Change log

- Added:
1. Drush 12 compatibility;
2. `drush.services.yml` files in the submodules `oe_paragraphs_banner` and `oe_paragraphs_carousel` with the drush commands declaration.

